### PR TITLE
Added JWT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ const netifi = Netifi.create({
     group: 'netifi-example',
   //destination: generated UUID if omitted  
     accessKey: 9007199254740991,
-    accessToken: 'kTBDVtfRBO4tHOnZzSyY5ym2kfY='
+    accessToken: 'kTBDVtfRBO4tHOnZzSyY5ym2kfY=',
+  //jwt: 'jwt.encoded.string' either a JWT or access key and token should be supplied, depending on your broker's auth setup.
   },
   transport: {
     url
@@ -51,11 +52,13 @@ export type NetifiConfig = {|
     tags?: Tags,
     keepAlive?: number,
     lifetime?: number,
-    accessKey: number,
-    accessToken: string,
+    accessKey?: number,
+    accessToken?: string,
+    jwt?: string,
     connectionId?: string,
     additionalFlags?: {|
       public?: boolean,
+      useJWT?: boolean
     |}
   |},
   transport: {|

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const netifi = Netifi.create({
   //destination: generated UUID if omitted  
     accessKey: 9007199254740991,
     accessToken: 'kTBDVtfRBO4tHOnZzSyY5ym2kfY=',
-  //jwt: 'jwt.encoded.string' either a JWT or access key and token should be supplied, depending on your broker's auth setup.
+  //jwt: 'jwt.encoded.string' depending on your broker's authentication setup, you can either provide an access key and token, or use a JWT.
   },
   transport: {
     url

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netifi-js-client",
-  "version": "1.6.9",
+  "version": "1.6.10-RC.0",
   "license": "SEE LICENSE IN ./LICENSE",
   "description": "Netifi JavaScript Client",
   "contributors": [

--- a/src/Netifi.js
+++ b/src/Netifi.js
@@ -24,7 +24,7 @@ import {
   ReactiveSocket,
   ISubscription,
 } from 'rsocket-types';
-import {Single, Flowable} from 'rsocket-flowable';
+import {Single} from 'rsocket-flowable';
 import type {PayloadSerializers} from 'rsocket-core/build/RSocketSerialization';
 import {BufferEncoders} from 'rsocket-core';
 import {RequestHandlingRSocket} from 'rsocket-rpc-core';
@@ -33,12 +33,11 @@ import invariant from 'fbjs/lib/invariant';
 import {DeferredConnectingRSocket, UnwrappingRSocket} from './rsocket';
 import {FrameTypes, encodeFrame} from './frames';
 import type {Tags} from './frames';
-
 import RSocketWebSocketClient from 'rsocket-websocket-client';
 import ConnectionId from './frames/ConnectionId';
+import {JWT_AUTHENTICATION} from './frames/DestinationSetupFlyweight';
 import AdditionalFlags from './frames/AdditionalFlags';
 import uuid from 'uuid/v4';
-
 import FlowableRpcClient from './rsocket/FlowableRpcClient';
 import type {ReactiveSocketOrError} from './rsocket/FlowableRpcClient';
 
@@ -50,8 +49,9 @@ export type NetifiConfig = {|
     tags?: Tags,
     keepAlive?: number,
     lifetime?: number,
-    accessKey: number,
-    accessToken: string,
+    accessKey?: number,
+    accessToken?: string,
+    jwt?: string,
     connectionId?: string,
     additionalFlags?: {|
       public?: boolean,
@@ -81,6 +81,7 @@ export default class Netifi {
   _lastConnectionAttemptTs: number;
   _lifetime: number;
   _reconnecting: boolean;
+  _shouldReconnect: boolean;
   _requestHandler: RequestHandlingRSocket;
   _rpcClientSubscriber: Object;
   _rpcClientSubscription: ISubscription;
@@ -103,6 +104,7 @@ export default class Netifi {
     this._subscribers = [];
     this._attempts = 0;
     this._reconnecting = false;
+    this._shouldReconnect = true;
 
     const destination =
       config.setup.destination !== undefined
@@ -124,9 +126,19 @@ export default class Netifi {
         ? config.setup.lifetime
         : 360000; /* 360s in ms */
 
-    this._accessKey = config.setup.accessKey;
-
-    this._accessToken = Buffer.from(config.setup.accessToken, 'base64');
+    if (config.setup.jwt) {
+      // get credentials from JWT
+      this._accessKey = JWT_AUTHENTICATION;
+      this._accessToken = Buffer.from(config.setup.jwt);
+    } else if (config.setup.accessKey && config.setup.accessToken) {
+      // get access key and token from config
+      this._accessKey = config.setup.accessKey;
+      this._accessToken = Buffer.from(config.setup.accessToken, 'base64');
+    } else {
+      throw new Error(
+        'Netifi: Credentials were not provided in config setup. Please provide either a JSON Web Token or an accessKey and accessToken.',
+      );
+    }
 
     const connectionIdSeed =
       typeof config.setup.connectionId !== 'undefined'
@@ -137,6 +149,7 @@ export default class Netifi {
 
     const additionalFlagsLiteral = {
       public: false,
+      useJWT: Boolean(config.setup.jwt),
       ...config.setup.additionalFlags,
     };
 
@@ -261,8 +274,8 @@ export default class Netifi {
   }
 
   _retryConnection(): void {
-    if (this._reconnecting) {
-      // a timeout is already running
+    if (this._reconnecting || !this._shouldReconnect) {
+      // a timeout is already running or close() was called
       return;
     }
     const retryDuration = this.calculateRetryDuration();
@@ -311,6 +324,7 @@ export default class Netifi {
   }
 
   close(): void {
+    this._shouldReconnect = false;
     this._client.close();
   }
 
@@ -330,12 +344,13 @@ export default class Netifi {
 
   static create(config: NetifiConfig): Netifi {
     invariant(
-      config &&
-        config.setup &&
-        config.setup.accessKey &&
-        config.setup.accessToken &&
-        config.transport,
-      'Netifi: Falsey config is invalid. At minimum transport config, group, access key, and access token are required.',
+      config && config.setup && config.transport,
+      'Netifi: Config is invalid. At minimum  a transport config, a group, and setup properties are required.',
+    );
+
+    invariant(
+      (config.setup.accessKey && config.setup.accessToken) || config.setup.jwt,
+      'Netifi: Config setup should provide either an access key and token, or a JSON Web Token.',
     );
 
     invariant(

--- a/src/__tests__/BinaryFraming-test.js
+++ b/src/__tests__/BinaryFraming-test.js
@@ -21,6 +21,7 @@ import ipaddr from 'ipaddr.js';
 
 import {encodeFrame, decodeFrame, FrameTypes} from '../frames';
 import ConnectionId from '../frames/ConnectionId';
+import {JWT_AUTHENTICATION} from '../frames/DestinationSetupFlyweight';
 import AdditionalFlags from '../frames/AdditionalFlags';
 
 describe('BROKER_SETUP', () => {
@@ -111,6 +112,30 @@ describe('DESTINATION_SETUP', () => {
     expect(input.accessToken).to.deep.equal(frame.accessToken);
     expect(input.tags).to.deep.equal(frame.tags);
     expect(input.additionalFlags.sum()).to.equal(frame.additionalFlags.sum());
+  });
+
+  it('updates the JWT flag if a JWT is provided in setup', () => {
+    const group = 'group';
+    const accessKey = JWT_AUTHENTICATION;
+    const accessToken = Buffer.from([0x0a, 0x0b, 0x0c]);
+    const tags = {key: 'value'};
+    const input = {
+      type: FrameTypes.DESTINATION_SETUP,
+      group,
+      accessKey,
+      accessToken,
+      tags,
+      connectionId: new ConnectionId('abc'),
+      additionalFlags: new AdditionalFlags({
+        public: false,
+        useJWT: true,
+      }),
+    };
+
+    const buffer = encodeFrame(input);
+    const frame = decodeFrame(buffer);
+    expect(input.additionalFlags.sum()).to.equal(2);
+    expect(frame.additionalFlags.sum()).to.equal(2);
   });
 });
 

--- a/src/__tests__/broker_info_netifi_pb-test.js
+++ b/src/__tests__/broker_info_netifi_pb-test.js
@@ -31,9 +31,10 @@ import {BrokerInfoServiceClient} from '../proto/netifi/broker_info_rsocket_pb';
 import {Empty} from 'google-protobuf/google/protobuf/empty_pb';
 
 import WebSocket from 'ws';
+import {JWT_AUTHENTICATION} from '../frames/DestinationSetupFlyweight';
 global.WebSocket = global.WebSocket || WebSocket;
 
-describe.skip('BrokerInfoServiceClient', () => {
+describe('BrokerInfoServiceClient', () => { // describe.skip
   it('retrieves brokers over WebSocket', async () => {
     const netifi = Netifi.create({
       setup: {
@@ -53,7 +54,7 @@ describe.skip('BrokerInfoServiceClient', () => {
     });
 
     const brokerInfoService = new BrokerInfoServiceClient(
-      netifi.group('com.netifi.brokerServices'),
+      netifi.group('com.netifi.broker.admin.brokerServices'),
     );
 
     const deferred = new Deferred();
@@ -101,7 +102,7 @@ describe.skip('BrokerInfoServiceClient', () => {
     });
 
     const brokerInfoService = new BrokerInfoServiceClient(
-      netifi.group('com.netifi.brokerServices'),
+      netifi.group('com.netifi.broker.admin.brokerServices'),
     );
 
     const deferred = new Deferred();
@@ -123,6 +124,64 @@ describe.skip('BrokerInfoServiceClient', () => {
       },
     });
     const broker = await deferred;
+    netifi.close();
+    expect(broker).to.not.equal(null);
+    expect(broker.brokerid).to.not.equal(undefined);
+  });
+
+  it('can use JWT for authentication', async () => {
+    const jwt =
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJ0ZXN0SWQiOiIxMTExODg4ODgiLCJzdWIiOiJ0ZXN0aW5nLWFwcCIsImF1ZCI6ImR1bmNhbkBuZXRpZmkuY29tIiwic2FzIjpbImRlZmF1bHQiLCJhY2NvdW50IiwidHJhbnNhY3Rpb24iXSwicm9sZXMiOlsiaW50ZXJuYWwiXSwiaXNzIjoiUlNvY2tldEJyb2tlciIsIm9yZ3MiOlsibmV0aWZpIl0sImlhdCI6MTU2NTYzMzMwOX0.Ax72zmzVHAKmP9NL8Wzze_cI3lgVog9GyiLN8FCyqm7jN9RGOax7oPROozvaZEbcQggzHoi3n8ddoWjkknmw4fFgWYUG0sEcUlxnPLrVowBVySdINLPO3tGOCQ3nqeyBTx9b1gLH2R1DEVp5N6ISl37cWH2offnZ-w_PGpj3XQHRBJsrq8XZXrxHogwFD4Vayy8QROS5JS-ab1iMBXgBJCJk4re9xWnBgTtrWj1uSnZWCJSLkk9v0gXxfd1lWrLvwyDkitnidyYZpRhLTWAjR8hoL2DSgTwqetZHMt6KEC-Y-jgaE8K7DoRLE-EaEZ8hP4AUf3Yn2A4qNyalysJaxw';
+
+    const netifi = Netifi.create({
+      setup: {
+        group: 'group',
+        keepAlive: 1000000,
+        lifetime: 100000,
+        jwt,
+      },
+      transport: {
+        url: 'wss://localhost:8101/',
+        wsCreator: url =>
+          new WebSocket(url, {
+            rejectUnauthorized: false,
+          }),
+      },
+    });
+
+    expect(netifi._jwt).to.not.equal(null);
+    expect(netifi._accessKey).to.equal(JWT_AUTHENTICATION);
+    expect(netifi._accessToken).to.be.instanceof(Buffer);
+
+    const brokerInfoService = new BrokerInfoServiceClient(
+      netifi.group('com.netifi.broker.admin.brokerServices'),
+    );
+
+    const deferred = new Deferred();
+    brokerInfoService.brokers(new Empty(), Buffer.alloc(0)).subscribe({
+      onComplete() {
+        console.log('onComplete()');
+      },
+      onError(error) {
+        console.log('onError(%s)', error.message);
+        deferred.reject(error);
+      },
+      onNext(broker) {
+        console.log('onNext(%o)', broker.toObject());
+        deferred.resolve(broker.toObject());
+      },
+      onSubscribe(subscription) {
+        subscription.request(MAX_REQUEST_N);
+      },
+    });
+    let broker;
+    try {
+      broker = await deferred;
+    }
+    catch(err) {
+      netifi.close();
+      throw err;
+    }
     netifi.close();
     expect(broker).to.not.equal(null);
     expect(broker.brokerid).to.not.equal(undefined);

--- a/src/frames/AdditionalFlags.js
+++ b/src/frames/AdditionalFlags.js
@@ -1,5 +1,6 @@
 const bitflags = {
   public: 1,
+  useJWT: 2,
 };
 
 export default class AdditionalFlags {

--- a/src/frames/DestinationSetupFlyweight.js
+++ b/src/frames/DestinationSetupFlyweight.js
@@ -46,6 +46,8 @@ const ADDITIONAL_FLAGS_SIZE = 2;
 const KEY_LENGTH_SIZE = 4;
 const VALUE_LENGTH_SIZE = 4;
 
+export const JWT_AUTHENTICATION = 0x01;
+
 export function encodeDestinationSetupFrame(
   frame: DestinationSetupFrame,
 ): Buffer {

--- a/src/rsocket/FlowableRpcClient.js
+++ b/src/rsocket/FlowableRpcClient.js
@@ -24,7 +24,6 @@ import type {
   Payload,
   ReactiveSocket,
   SetupFrame,
-  Responder,
 } from 'rsocket-types';
 
 import {Flowable, Single, every} from 'rsocket-flowable';

--- a/src/rx/FlowableAdapter.js
+++ b/src/rx/FlowableAdapter.js
@@ -36,9 +36,17 @@ export default function toObservable(
   rsocketType: Flowable<T> | Single<T>,
   batchSize?: number,
 ) {
-  if (rsocketType instanceof Flowable || rsocketType.constructor.name === Flowable.name || rsocketType.constructor.name === 'Flowable') {
+  if (
+    rsocketType instanceof Flowable ||
+    rsocketType.constructor.name === Flowable.name ||
+    rsocketType.constructor.name === 'Flowable'
+  ) {
     return from(new ObservableFlowable(rsocketType, batchSize));
-  } else if (rsocketType instanceof Single || rsocketType.constructor.name === Single.name || rsocketType.constructor.name === 'Single') {
+  } else if (
+    rsocketType instanceof Single ||
+    rsocketType.constructor.name === Single.name ||
+    rsocketType.constructor.name === 'Single'
+  ) {
     return from(new ObservableSingle(rsocketType));
   } else {
     console.log('Unrecognized type: ' + rsocketType);


### PR DESCRIPTION
Users can pass a JWT in at client setup to use JWT auth with the broker. Also ran Prettier and fixed an issue with the client trying to reconnect after `netifi.close()` had already been called.